### PR TITLE
Prevent warning on container init

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ This Beets plugin solves both problems.
    #!/bin/bash
    echo "Installing dependencies..."
    # copyartifacts is optional but recommended
-   pip install markdownify natsort beets-copyartifacts3
+   pip install --no-cache-dir markdownify natsort beets-copyartifacts3
    ```
 
 4. Clone this repository into the `plugins` folder.


### PR DESCRIPTION
Prevents the following warning
```
WARNING: The directory '/config/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
```