### PR TITLE
Capitalize language on book object init

### DIFF
--- a/book.py
+++ b/book.py
@@ -71,7 +71,7 @@ class Book:
         self.format_type = format_type
         self.genres = genres
         self.image_url = image_url
-        self.language = language
+        self.language = language.capitalize()
         self.narrators = narrators
         self.publisher = publisher
         self.release_date = release_date


### PR DESCRIPTION
This will result in data from audnex.us having properly capitalized languages. In English, language names should be capitalized. https://www.grammarly.com/blog/capitalization-countries-nationalities-languages/

Fixes: #4