### PR TITLE
Search goodreads for original published date of source book

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,5 @@
 import json
+import xml.etree.ElementTree as ET
 from time import sleep
 from typing import Dict, Tuple
 from urllib import parse, request
@@ -7,6 +8,7 @@ from .book import Book, BookChapters
 
 AUDIBLE_ENDPOINT="https://api.audible.com/1.0/catalog/products"
 AUDNEX_ENDPOINT="https://api.audnex.us"
+GOODREADS_ENDPOINT="https://www.goodreads.com"
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
 
 def search_audible(keywords: str) -> Dict:
@@ -19,6 +21,23 @@ def search_audible(keywords: str) -> Dict:
     query = parse.urlencode( params )
     response = json.loads(make_request(f"{AUDIBLE_ENDPOINT}?{query}"))
     return response
+
+def search_goodreads(asin: str, api_key: str) -> Dict:
+    goodreads_response = ET.fromstring(make_request(f"{GOODREADS_ENDPOINT}/search/index.xml?key={api_key}&q={asin}"))
+
+    totalresults = int(goodreads_response.findtext("./search/total-results"))
+    original_date = {}
+
+    if totalresults == 1:
+        #if just one match assume it is correct for now
+        work = goodreads_response.find("./search/results/work")
+        original_date["year"] = int(work.findtext("original_publication_year"))
+        original_date["month"] = int(work.findtext("original_publication_month"))
+        original_date["day"] = int(work.findtext("original_publication_day"))
+
+        print(original_date)
+    
+    return original_date
 
 def get_book_info(asin: str) -> Tuple[Book, BookChapters]:
     book_response = json.loads(make_request(f"{AUDNEX_ENDPOINT}/books/{asin}"))

--- a/api.py
+++ b/api.py
@@ -34,8 +34,6 @@ def search_goodreads(asin: str, api_key: str) -> Dict:
         original_date["year"] = int(work.findtext("original_publication_year"))
         original_date["month"] = int(work.findtext("original_publication_month"))
         original_date["day"] = int(work.findtext("original_publication_day"))
-
-        print(original_date)
     
     return original_date
 

--- a/audible.py
+++ b/audible.py
@@ -340,10 +340,10 @@ class Audible(BeetsPlugin):
 
         if self.config['goodreads_apikey']:
             original_date = search_goodreads(asin, self.config['goodreads_apikey'])
-            if original_date["year"]:
-                original_year=original_date["year"]
-                original_month=original_date["month"]
-                original_day=original_date["day"]
+            if original_date.get("year") is not None:
+                original_year=original_date.get("year")
+                original_month=original_date.get("month")
+                original_day=original_date.get("day")
         
         return AlbumInfo(
             tracks=tracks, album=album, album_id=None, albumtype="audiobook", mediums=1,

--- a/audible.py
+++ b/audible.py
@@ -12,7 +12,7 @@ from beets.plugins import BeetsPlugin, get_distance
 import mediafile
 from natsort import os_sorted
 
-from .api import get_book_info, make_request, search_audible
+from .api import get_book_info, make_request, search_audible, search_goodreads
 
 class Audible(BeetsPlugin):
     data_source = 'Audible'
@@ -333,10 +333,22 @@ class Audible(BeetsPlugin):
         data_url = f"https://api.audnex.us/books/{asin}"
 
         self.cover_art_urls[asin] = cover_url
+
+        original_year=year
+        original_month=month
+        original_day=day
+
+        if self.config['goodreads_apikey']:
+            original_date = search_goodreads(asin, self.config['goodreads_apikey'])
+            if original_date["year"]:
+                original_year=original_date["year"]
+                original_month=original_date["month"]
+                original_day=original_date["day"]
+        
         return AlbumInfo(
             tracks=tracks, album=album, album_id=None, albumtype="audiobook", mediums=1,
             artist=authors, year=year, month=month, day=day,
-            original_year=year, original_month=month, original_day=day,
+            original_year=original_year, original_month=original_month, original_day=original_day,
             cover_url=cover_url, summary_html=book.summary_html,
             is_chapter_data_accurate=is_chapter_data_accurate,
             language=book.language, label=book.publisher, **common_attributes

--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,9 @@ The plugin can search Goodreads to find the original publication date of the wor
      goodreads_apikey: [APIKEYHERE] #optional
 ```
 
+If you want this date used as the release date for the audiobook, you must set [original_date](https://beets.readthedocs.io/en/stable/reference/config.html#original-date) to yes in your beets config
+
+
 ### Importing Non-Audible Content
 
 The plugin looks for a file called `metadata.yml` in each book's folder during import. If this file is present, it exclusively uses the info in it for tagging and skips the Audible lookup.

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,15 @@ If you're not getting a match for a book, try the following:
 
 The plugin gets chapter data of each book and tries to match them to the imported files if and only if the number of imported files is the same as the number of chapters from Audible. This can fail and cause inaccurate track assignments if the lengths of the files don't match Audible's chapter data. If this happens, set the config option `match_chapters` to `false` temporarily and try again, and remember to uncomment that line once done.
 
+### Goodreads for original work first published date
+
+The plugin can search Goodreads to find the original publication date of the work the audiobook is based on by searching on the ASIN. To enable this option you need a Goodreads API key and you must set that key in the audible plugin config
+
+```
+   audible:
+     goodreads_apikey: [APIKEYHERE] #optional
+```
+
 ### Importing Non-Audible Content
 
 The plugin looks for a file called `metadata.yml` in each book's folder during import. If this file is present, it exclusively uses the info in it for tagging and skips the Audible lookup.


### PR DESCRIPTION
Adds a new config option `goodreads_apikey` to audible. If present goodreads will be searched using the ASIN for the original publication date of the work.

This will address the missing original_date I mentioned in #2