### PR TITLE
Multiple Candidates and catalognum

### DIFF
--- a/audible.py
+++ b/audible.py
@@ -371,7 +371,7 @@ class Audible(BeetsPlugin):
                 original_day=original_date.get("day")
         
         return AlbumInfo(
-            tracks=tracks, album=album, album_id=None, albumtype="audiobook", mediums=1,
+            tracks=tracks, album=album, album_id=asin, albumtype="audiobook", mediums=1,
             artist=authors, year=year, month=month, day=day,
             original_year=original_year, original_month=original_month, original_day=original_day,
             cover_url=cover_url, summary_html=book.summary_html,
@@ -381,6 +381,7 @@ class Audible(BeetsPlugin):
     
     def on_write(self, item, path, tags):
         # Strip unwanted tags that Beets automatically adds
+        tags['mb_albumid'] = None
         tags['mb_trackid'] = None
         tags['lyrics'] = None
         tags['bpm'] = None

--- a/audible.py
+++ b/audible.py
@@ -339,6 +339,7 @@ class Audible(BeetsPlugin):
             "composer": narrators, "grouping": content_group_description,
             "genre": genres, "series_name": series_name, "series_position": series_position,
             "comments": description, "data_source": self.data_source, "subtitle": subtitle,
+            "catalognum": asin
         }
 
         tracks = [


### PR DESCRIPTION
Setting album_id to ASIN. This allows multiple candidates to be presented to the user.

No notable ill effects. I remove mb_albumid from tags before they are written.

Set catalognum to ASIN. This will now display catalognum in the candidate list and calculate distance based on different catalognums

![image](https://user-images.githubusercontent.com/991618/170801343-0ff3b057-426f-4d5b-bd50-2160ac1650fd.png)
