### PR TITLE
Options to remove series related info from title and subtitle

### DIFF
--- a/audible.py
+++ b/audible.py
@@ -310,7 +310,6 @@ class Audible(BeetsPlugin):
 
             title_cruft = f", Book {series_position}"
             if self.config['remove_series_reference_in_title'] and title.endswith(title_cruft):
-                #clean up title
                 #check if ', Book X' is in title, remove it
                 self._log.debug(f"Title contains '{title_cruft}'. Removing it.")
                 title = title.removesuffix(title_cruft)

--- a/audible.py
+++ b/audible.py
@@ -301,7 +301,6 @@ class Audible(BeetsPlugin):
         
         release_date = book.release_date
         series = book.series
-        album = title
         
         if series:
             series_name = series.name
@@ -371,7 +370,7 @@ class Audible(BeetsPlugin):
                 original_day=original_date.get("day")
         
         return AlbumInfo(
-            tracks=tracks, album=album, album_id=None, albumtype="audiobook", mediums=1,
+            tracks=tracks, album=title, album_id=None, albumtype="audiobook", mediums=1,
             artist=authors, year=year, month=month, day=day,
             original_year=original_year, original_month=original_month, original_day=original_day,
             cover_url=cover_url, summary_html=book.summary_html,

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,8 @@ This Beets plugin solves both problems.
      source_weight: 0.0 # disable the source_weight penalty
      fetch_art: true # whether to retrieve cover art
      include_narrator_in_artists: true # include author and narrator in artist tag. Or just author
+     remove_series_reference_in_title: false # remove ", Book X" from end of titles
+     remove_series_reference_in_subtitle: false # remove subtitle if it contains the series name and the word book ex. "Book 1 in Great Series", "Great Series, Book 1"
 
    copyartifacts:
      extensions: .yml # so that metadata.yml is copied, see below


### PR DESCRIPTION
Adds a couple new options to remove series related info in title and subtitle. Default options maintains the current behavior.

```
remove_series_reference_in_title: false # remove ", Book X" from end of titles
remove_series_reference_in_subtitle: false # remove subtitle if it contains the series name and the word book ex. "Book 1 in Great Series", "Great 
```

Addresses `Book` in the title I brought up in #2