### PR TITLE
Fix an exception ruining all results

### DIFF
--- a/audible.py
+++ b/audible.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import pathlib
 import re
+import urllib.error
 from tempfile import NamedTemporaryFile
 import yaml
 
@@ -287,8 +288,13 @@ class Audible(BeetsPlugin):
             if len(products_without_unreleased_entries) < len(products):
                 # see https://github.com/laxamentumtech/audnexus/issues/239
                 self._log.info(f"Excluded {len(products) - len(products_without_unreleased_entries)} books which have not been released from consideration.")
-            
-            return [self.get_album_info(p["asin"]) for p in products_without_unreleased_entries]
+            out = []
+            for p in products_without_unreleased_entries:
+                try:
+                    out.append(self.get_album_info(p['asin']))
+                except urllib.error.HTTPError:
+                    pass
+            return out
         except Exception as e:
             self._log.warn("Error while fetching book information from Audnex",
                             exc_info=True)

--- a/audible.py
+++ b/audible.py
@@ -293,7 +293,7 @@ class Audible(BeetsPlugin):
                 try:
                     out.append(self.get_album_info(p['asin']))
                 except urllib.error.HTTPError:
-                    pass
+                    self._log.debug("Error while fetching book information from Audnex", exc_info=True)
             return out
         except Exception as e:
             self._log.warn("Error while fetching book information from Audnex",


### PR DESCRIPTION
So not all books returned by the Audnex API have chapters, which causes an exception. However, when this happens, it throws out any other results that the API has returned, meaning that there are no results at all. This just introduces a for loop that discards results that have this exception.