### PR TITLE
Limit API calls that end with 404 error

### DIFF
--- a/api.py
+++ b/api.py
@@ -53,6 +53,9 @@ def make_request(url):
             with request.urlopen(req) as response:
                 return response.read()
         except HTTPError as e:
+            if e.code == 404:
+                print(f"Error while requesting {url}: status code {e.code}, {e.reason}")
+                raise e
             print(f"Error while requesting {url}, attempt {n+1}/{NUM_RETRIES}: status code {e.code}, {e.reason}")
             if n < NUM_RETRIES - 1:
                 sleep(SLEEP_TIME)


### PR DESCRIPTION
When there are chapter errors with Audnex, the API responds with a 404 error. There isn't any point to retrying these kinds of errors as they won't change, and it makes unnecessary calls to the API. To prevent overuse and follow internet etiquette, this PR just immediately raises the error if the error code is 404 instead of retrying.