### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,11 @@ beets = "1.6.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 skip_install = True
 commands =
     isort beetsplug tests
-    black beetsplug tests --line-length 120
+    black beetsplug tests
 
 [testenv:lint]
 deps =
@@ -25,7 +25,3 @@ commands =
 deps =
     pytest
 commands = pytest
-
-[isort]
-profile = black
-multi_line_output = 3


### PR DESCRIPTION
This adds support for the pre-commit tool, which allows the formatters to be run before each commit to automate the process.

Also it's possible to add a markdown linter, would you be interested in that?