### PR TITLE
Use rate limit retry-after response header to set sleep duration

### DIFF
--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -64,6 +64,12 @@ def make_request(url: str) -> bytes:
             if e.code == 404:
                 print(f"Error while requesting {url}: status code {e.code}, {e.reason}")
                 raise e
+            if e.code == 429:
+                reset_seconds = e.headers.get('retry-after')
+                if reset_seconds:
+                    reset_seconds = int(reset_seconds)
+                    print(f"got ratelimited, rate limit resets in {reset_seconds}, updating sleep duration")
+                    sleep_time = reset_seconds + 1
             print(f"Error while requesting {url}, attempt {n+1}/{num_retries}: status code {e.code}, {e.reason}")
             if n < num_retries - 1:
                 sleep(sleep_time)


### PR DESCRIPTION
When being rate limited, we get a retry-after header which tells us how long to wait before retrying, let's use it.
