### PR TITLE
Support different regions for Audible and Audnex API

### DIFF
--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -49,9 +49,9 @@ def search_goodreads(api_key: str, keywords: str) -> ET.Element:
 
 def get_book_info(asin: str, region: str) -> Tuple[Book, BookChapters]:
     book_response = json.loads(make_request(
-        f"{AUDNEX_ENDPOINT}/books/{asin}?region={region}"))
+        f"{AUDNEX_ENDPOINT}/books/{asin}?region={region}&update=1"))
     chapter_response = json.loads(make_request(
-        f"{AUDNEX_ENDPOINT}/books/{asin}/chapters?region={region}"))
+        f"{AUDNEX_ENDPOINT}/books/{asin}/chapters?region={region}&update=1"))
     book = Book.from_audnex_book(book_response)
     book_chapters = BookChapters.from_audnex_chapter_info(chapter_response)
     return book, book_chapters

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -59,8 +59,10 @@ def get_book_info(asin: str, region: str) -> Tuple[Book, BookChapters]:
     book_chapters = BookChapters.from_audnex_chapter_info(chapter_response)
     return book, book_chapters
 
+
 def get_audible_album_url(asin: str, region: str) -> str:
     return f'https://www.audible.{AUDIBLE_REGIONS_SUFFIXES[region]}/pd/{asin}'
+
 
 def get_audible_album_region(url: str) -> Optional[str]:
     suffix = tldextract.extract(url).suffix

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -2,7 +2,7 @@ import tldextract
 import json
 import xml.etree.ElementTree as ET
 from time import sleep
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 from urllib import parse, request
 from urllib.error import HTTPError
 
@@ -62,7 +62,7 @@ def get_book_info(asin: str, region: str) -> Tuple[Book, BookChapters]:
 def get_audible_album_url(asin: str, region: str) -> str:
     return f'https://www.audible.{AUDIBLE_REGIONS_SUFFIXES[region]}/pd/{asin}'
 
-def get_audible_album_region(url: str) -> str:
+def get_audible_album_region(url: str) -> Optional[str]:
     if url is None:
         return None
     else:

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -1,3 +1,4 @@
+import tldextract
 import json
 import xml.etree.ElementTree as ET
 from time import sleep
@@ -7,7 +8,6 @@ from urllib.error import HTTPError
 
 from .book import Book, BookChapters
 
-AUDIBLE_REGIONS = ("au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk")
 AUDIBLE_ENDPOINTS = {
     "au": "https://api.audible.com.au/1.0/catalog/products",
     "ca": "https://api.audible.ca/1.0/catalog/products",
@@ -20,6 +20,9 @@ AUDIBLE_ENDPOINTS = {
     "us": "https://api.audible.com/1.0/catalog/products",
     "uk": "https://api.audible.co.uk/1.0/catalog/products"
 }
+AUDIBLE_REGIONS = set(AUDIBLE_ENDPOINTS.keys())
+AUDIBLE_REGIONS_SUFFIXES = {k: tldextract.extract(v).suffix for k, v in AUDIBLE_ENDPOINTS.items()}
+AUDIBLE_SUFFIXES_REGIONS = {v: k for k, v in AUDIBLE_REGIONS_SUFFIXES.items()}
 AUDNEX_ENDPOINT = "https://api.audnex.us"
 GOODREADS_ENDPOINT = "https://www.goodreads.com/search/index.xml"
 USER_AGENT = (
@@ -56,6 +59,12 @@ def get_book_info(asin: str, region: str) -> Tuple[Book, BookChapters]:
     book_chapters = BookChapters.from_audnex_chapter_info(chapter_response)
     return book, book_chapters
 
+def get_audible_album_url(asin: str, region: str) -> str:
+    return f'https://www.audible.{AUDIBLE_REGIONS_SUFFIXES[region]}/pd/{asin}'
+
+def get_audible_album_region(url: str) -> str:
+    suffix = tldextract.extract(url).suffix
+    return AUDIBLE_SUFFIXES_REGIONS[suffix]
 
 def make_request(url: str) -> bytes:
     """Makes a request to the specified url and returns received response

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -7,8 +7,8 @@ from urllib.error import HTTPError
 
 from .book import Book, BookChapters
 
-AUDIBLE_REGION = ("au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk")
-AUDIBLE_ENDPOINT = {
+AUDIBLE_REGIONS = ("au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk")
+AUDIBLE_ENDPOINTS = {
     "au": "https://api.audible.com.au/1.0/catalog/products",
     "ca": "https://api.audible.ca/1.0/catalog/products",
     "de": "https://api.audible.de/1.0/catalog/products",
@@ -36,7 +36,7 @@ def search_audible(keywords: str, region: str) -> Dict:
         "keywords": keywords,
     }
     query = parse.urlencode(params)
-    response = json.loads(make_request(f"{AUDIBLE_ENDPOINT[region]}?{query}"))
+    response = json.loads(make_request(f"{AUDIBLE_ENDPOINTS[region]}?{query}"))
     return response
 
 

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -63,8 +63,11 @@ def get_audible_album_url(asin: str, region: str) -> str:
     return f'https://www.audible.{AUDIBLE_REGIONS_SUFFIXES[region]}/pd/{asin}'
 
 def get_audible_album_region(url: str) -> str:
-    suffix = tldextract.extract(url).suffix
-    return AUDIBLE_SUFFIXES_REGIONS[suffix]
+    if url is None:
+        return None
+    else:
+        suffix = tldextract.extract(url).suffix
+        return AUDIBLE_SUFFIXES_REGIONS[suffix]
 
 def make_request(url: str) -> bytes:
     """Makes a request to the specified url and returns received response

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -7,7 +7,19 @@ from urllib.error import HTTPError
 
 from .book import Book, BookChapters
 
-AUDIBLE_ENDPOINT = "https://api.audible.com/1.0/catalog/products"
+AUDIBLE_REGION = ("au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk")
+AUDIBLE_ENDPOINT = {
+    "au": "https://api.audible.com.au/1.0/catalog/products",
+    "ca": "https://api.audible.ca/1.0/catalog/products",
+    "de": "https://api.audible.de/1.0/catalog/products",
+    "es": "https://api.audible.es/1.0/catalog/products",
+    "fr": "https://api.audible.fr/1.0/catalog/products",
+    "in": "https://api.audible.in/1.0/catalog/products",
+    "it": "https://api.audible.it/1.0/catalog/products",
+    "jp": "https://api.audible.co.jp/1.0/catalog/products",
+    "us": "https://api.audible.com/1.0/catalog/products",
+    "uk": "https://api.audible.co.uk/1.0/catalog/products"
+}
 AUDNEX_ENDPOINT = "https://api.audnex.us"
 GOODREADS_ENDPOINT = "https://www.goodreads.com/search/index.xml"
 USER_AGENT = (
@@ -16,7 +28,7 @@ USER_AGENT = (
 )
 
 
-def search_audible(keywords: str) -> Dict:
+def search_audible(keywords: str, region: str) -> Dict:
     params = {
         "response_groups": "contributors,product_attrs,product_desc,product_extended_attrs,series",
         "num_results": 10,
@@ -24,7 +36,7 @@ def search_audible(keywords: str) -> Dict:
         "keywords": keywords,
     }
     query = parse.urlencode(params)
-    response = json.loads(make_request(f"{AUDIBLE_ENDPOINT}?{query}"))
+    response = json.loads(make_request(f"{AUDIBLE_ENDPOINT[region]}?{query}"))
     return response
 
 
@@ -35,9 +47,11 @@ def search_goodreads(api_key: str, keywords: str) -> ET.Element:
     return ET.fromstring(make_request(url))
 
 
-def get_book_info(asin: str) -> Tuple[Book, BookChapters]:
-    book_response = json.loads(make_request(f"{AUDNEX_ENDPOINT}/books/{asin}"))
-    chapter_response = json.loads(make_request(f"{AUDNEX_ENDPOINT}/books/{asin}/chapters"))
+def get_book_info(asin: str, region: str) -> Tuple[Book, BookChapters]:
+    book_response = json.loads(make_request(
+        f"{AUDNEX_ENDPOINT}/books/{asin}?region={region}"))
+    chapter_response = json.loads(make_request(
+        f"{AUDNEX_ENDPOINT}/books/{asin}/chapters?region={region}"))
     book = Book.from_audnex_book(book_response)
     book_chapters = BookChapters.from_audnex_chapter_info(chapter_response)
     return book, book_chapters

--- a/beetsplug/api.py
+++ b/beetsplug/api.py
@@ -63,11 +63,12 @@ def get_audible_album_url(asin: str, region: str) -> str:
     return f'https://www.audible.{AUDIBLE_REGIONS_SUFFIXES[region]}/pd/{asin}'
 
 def get_audible_album_region(url: str) -> Optional[str]:
-    if url is None:
-        return None
-    else:
-        suffix = tldextract.extract(url).suffix
+    suffix = tldextract.extract(url).suffix
+    if suffix in AUDIBLE_SUFFIXES_REGIONS.keys():
         return AUDIBLE_SUFFIXES_REGIONS[suffix]
+    else:
+        return None
+
 
 def make_request(url: str) -> bytes:
     """Makes a request to the specified url and returns received response

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -556,53 +556,11 @@ class Audible(BeetsPlugin):
 
     def before_choose_candidate_event(self, session, task):
         return [
-            PromptChoice('r', 'switch Region', self.switch_region_config),
-            PromptChoice('f', 'switch region For this book', self.switch_region_book)
+            PromptChoice('r', 'Region switch', self.book_level_region_switch)
         ]
 
-    # The configuration level switch may not be a good idea, as it may not work well with background processes.
-    def switch_region_config(self, session, task):
-        """Prompts the config level region value"""
-        available_region_codes = ', '.join(
-            (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
-        )
-
-        # config level region code
-        current_config_region_code = self.config['region'].get()
-
-        # book level region code
-        book_region_code = get_item_region(task.items[0])
-        if book_region_code is None:
-            current_book_region_code = '--'
-        else:
-            current_book_region_code = book_region_code
-
-        message = (
-            f'Enter region code '
-            f'({available_region_codes}) '
-            f'[{current_config_region_code}]'
-            f'[{ui.colorize("text_faint", current_book_region_code)}] '
-            f'(config): '
-        )
-        
-        color_name = 'text'
-        region_code = ui.input_(message)
-        
-        if region_code in AUDIBLE_REGIONS:
-            self.config['region'] = region_code
-            if current_config_region_code != region_code:
-                color_name = 'changed'
-                current_config_region_code = region_code
-
-        ui.print_(
-            'Current config region code:',
-            ui.colorize(color_name, current_config_region_code)
-        )
-
-        task.lookup_candidates()
-
-    def switch_region_book(self, session, task):
-        """Prompts the book's level region value"""
+    def book_level_region_switch(self, session, task):
+        """Prompts the book level region value"""
         available_region_codes = ', '.join(
             (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
         )
@@ -625,8 +583,7 @@ class Audible(BeetsPlugin):
             f'Enter region code '
             f'({available_region_codes}) '
             f'[{ui_current_config_region_code}]'
-            f'[{ui_current_book_region_code}] '
-            f'(book): '
+            f'[{ui_current_book_region_code}]: '
         )
         
         color_name = 'text'
@@ -639,11 +596,12 @@ class Audible(BeetsPlugin):
                 current_book_region_code = region_code
 
         ui.print_(
-            "Current book's region code:",
+            "Current book region code:",
             ui.colorize(color_name, current_book_region_code)
         )
 
         task.lookup_candidates()
+
 
 def get_item_region(item):
     """Get the value of the 'region' field, if it is available, or can be extracted from 'album_url'."""

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -615,7 +615,7 @@ def get_item_region(item):
         region = item['region']
     
     # The current value of the 'region' field takes precedence over the value extracted from the 'album_url' field.
-    if region is not None:
+    if (region is not None) and (region in AUDIBLE_REGIONS):
         result = region
     elif album_url is not None:
         result = get_audible_album_region(album_url)

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -623,10 +623,22 @@ class Audible(BeetsPlugin):
         task.lookup_candidates()
 
 def get_item_region(item):
-    album_url = item['album_url']
-    region = item['region']
+    """Get the value of the 'region' field, if it is available, or can be extracted from 'album_url'."""
+    available_field_names = item.keys()
+    album_url = None
+    region = None
+
+    if 'album_url' in available_field_names:
+        album_url = item['album_url']
+
+    if 'region' in available_field_names:
+        region = item['region']
+    
+    # The current value of the 'region' field takes precedence over the value extracted from the 'album_url' field.
     if region is not None:
         result = region
-    else:
+    elif album_url is not None:
         result = get_audible_album_region(album_url)
+    else:
+        result = None
     return result

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -561,7 +561,7 @@ class Audible(BeetsPlugin):
     def book_level_region_switch(self, session, task):
         """Prompts the book level region value"""
         available_region_codes = ', '.join(
-            (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
+            (ui.colorize(UI_COLOR_NAMES["added"], reg) for reg in AUDIBLE_REGIONS)
         )
 
         # config level region code
@@ -571,12 +571,12 @@ class Audible(BeetsPlugin):
         book_region_code = get_item_region(task.items[0])
         if book_region_code is None:
             current_book_region_code = '--'
-            ui_current_config_region_code = ui.colorize("text", current_config_region_code)
-            ui_current_book_region_code = ui.colorize("text", current_book_region_code)
+            ui_current_config_region_code = ui.colorize(UI_COLOR_NAMES["text"], current_config_region_code)
+            ui_current_book_region_code = ui.colorize(UI_COLOR_NAMES["text"], current_book_region_code)
         else:
             current_book_region_code = book_region_code
-            ui_current_config_region_code = ui.colorize("text_faint", current_config_region_code)
-            ui_current_book_region_code = ui.colorize("text", current_book_region_code)
+            ui_current_config_region_code = ui.colorize(UI_COLOR_NAMES["text_faint"], current_config_region_code)
+            ui_current_book_region_code = ui.colorize(UI_COLOR_NAMES["text"], current_book_region_code)
 
         message = (
             f'Enter region code '
@@ -585,13 +585,13 @@ class Audible(BeetsPlugin):
             f'[{ui_current_book_region_code}]: '
         )
         
-        color_name = 'text'
+        color_name = UI_COLOR_NAMES["text"]
         region_code = ui.input_(message)
         
         if region_code in AUDIBLE_REGIONS:
             task.items[0]['region'] = region_code
             if current_book_region_code != region_code:
-                color_name = 'changed'
+                color_name = UI_COLOR_NAMES["changed"]
                 current_book_region_code = region_code
 
         ui.print_(
@@ -622,3 +622,12 @@ def get_item_region(item):
     else:
         result = None
     return result
+
+
+# UI color names fallbacks.
+UI_COLOR_NAMES = {
+    "added": "added" if "added" in ui.COLOR_NAMES else "darkgreen",
+    "text": "text" if "text" in ui.COLOR_NAMES else "lightgray",
+    "text_faint": "text_faint" if "text_faint" in ui.COLOR_NAMES else "darkgray",
+    "changed": "changed" if "changed" in ui.COLOR_NAMES else "darkyellow",
+}

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -33,6 +33,7 @@ class Audible(BeetsPlugin):
                 "keep_series_reference_in_title": True,
                 "keep_series_reference_in_subtitle": True,
                 "goodreads_apikey": None,
+                "region": "us",
             }
         )
         self.config["goodreads_apikey"].redact = True
@@ -293,7 +294,7 @@ class Audible(BeetsPlugin):
     def get_albums(self, query):
         """Returns a list of AlbumInfo objects for an Audible search query."""
         try:
-            results = search_audible(query)
+            results = search_audible(query, region=self.config['region'])
         except Exception as e:
             self._log.warn("Could not connect to Audible API while searching for {0!r}", query, exc_info=True)
             return []
@@ -321,7 +322,7 @@ class Audible(BeetsPlugin):
 
     def get_album_info(self, asin):
         """Returns an AlbumInfo object for a book given its asin."""
-        (book, chapters) = get_book_info(asin)
+        (book, chapters) = get_book_info(asin, region=self.config['region'])
 
         title = book.title
         subtitle = book.subtitle

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -313,7 +313,7 @@ class Audible(BeetsPlugin):
     def get_albums(self, query, region=None):
         """Returns a list of AlbumInfo objects for an Audible search query."""
 
-        # The book level region has a higher priority than the config.
+        # The book level region has a higher priority than the config level.
         if region is None:
             region = self.config['region'].get()
 
@@ -346,6 +346,7 @@ class Audible(BeetsPlugin):
 
     def get_album_info(self, asin, region=None):
         """Returns an AlbumInfo object for a book given its asin."""
+
         if region is None:
             region = self.config['region'].get()
         

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -39,6 +39,8 @@ class Audible(BeetsPlugin):
             }
         )
         self.config["goodreads_apikey"].redact = True
+        # Check that a 'region' value in the config is one of the provided choices
+        self.config['region'].as_choice(AUDIBLE_REGIONS)
         # Mapping of asin to cover art urls
         self.cover_art_urls = {}
         # stores paths of downloaded cover art to be used during import

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -566,11 +566,23 @@ class Audible(BeetsPlugin):
         available_region_codes = ', '.join(
             (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
         )
-        current_region_code = self.config['region'].get()
+
+        # config level region code
+        current_config_region_code = self.config['region'].get()
+
+        # book level region code
+        book_region_code = get_item_region(task.items[0])
+        if book_region_code is None:
+            current_book_region_code = '--'
+        else:
+            current_book_region_code = book_region_code
+
         message = (
             f'Enter region code '
             f'({available_region_codes}) '
-            f'[{current_region_code}]: '
+            f'[{current_config_region_code}]'
+            f'[{ui.colorize("text_faint", current_book_region_code)}] '
+            f'(config): '
         )
         
         color_name = 'text'
@@ -578,32 +590,43 @@ class Audible(BeetsPlugin):
         
         if region_code in AUDIBLE_REGIONS:
             self.config['region'] = region_code
-            if current_region_code != region_code:
+            if current_config_region_code != region_code:
                 color_name = 'changed'
-                current_region_code = region_code
+                current_config_region_code = region_code
 
         ui.print_(
-            'Current region code:',
-            ui.colorize(color_name, current_region_code)
+            'Current config region code:',
+            ui.colorize(color_name, current_config_region_code)
         )
 
         task.lookup_candidates()
 
     def switch_region_book(self, session, task):
+        """Prompts the book's level region value"""
         available_region_codes = ', '.join(
             (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
         )
 
-        book_region_code = get_item_region(task.items[0])
+        # config level region code
+        current_config_region_code = self.config['region'].get()
 
+        # book level region code
+        book_region_code = get_item_region(task.items[0])
         if book_region_code is None:
-            current_region_code = self.config['region'].get()
+            current_book_region_code = '--'
+            ui_current_config_region_code = ui.colorize("text", current_config_region_code)
+            ui_current_book_region_code = ui.colorize("text", current_book_region_code)
         else:
-            current_region_code = book_region_code
+            current_book_region_code = book_region_code
+            ui_current_config_region_code = ui.colorize("text_faint", current_config_region_code)
+            ui_current_book_region_code = ui.colorize("text", current_book_region_code)
+
         message = (
             f'Enter region code '
             f'({available_region_codes}) '
-            f'[{current_region_code}]: '
+            f'[{ui_current_config_region_code}]'
+            f'[{ui_current_book_region_code}] '
+            f'(book): '
         )
         
         color_name = 'text'
@@ -611,13 +634,13 @@ class Audible(BeetsPlugin):
         
         if region_code in AUDIBLE_REGIONS:
             task.items[0]['region'] = region_code
-            if current_region_code != region_code:
+            if current_book_region_code != region_code:
                 color_name = 'changed'
-                current_region_code = region_code
+                current_book_region_code = region_code
 
         ui.print_(
-            'Current region code:',
-            ui.colorize(color_name, current_region_code)
+            "Current book's region code:",
+            ui.colorize(color_name, current_book_region_code)
         )
 
         task.lookup_candidates()

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -312,6 +312,8 @@ class Audible(BeetsPlugin):
 
     def get_albums(self, query, region=None):
         """Returns a list of AlbumInfo objects for an Audible search query."""
+
+        # The book level region has a higher priority than the config.
         if region is None:
             region = self.config['region'].get()
 
@@ -558,7 +560,9 @@ class Audible(BeetsPlugin):
             PromptChoice('f', 'switch region For this book', self.switch_region_book)
         ]
 
+    # The configuration level switch may not be a good idea, as it may not work well with background processes.
     def switch_region_config(self, session, task):
+        """Prompts the config level region value"""
         available_region_codes = ', '.join(
             (ui.colorize("added", reg) for reg in AUDIBLE_REGIONS)
         )

--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -13,7 +13,8 @@ from beets.plugins import BeetsPlugin, get_distance
 from beets.ui.commands import PromptChoice
 from natsort import os_sorted
 
-from .api import get_book_info, make_request, search_audible, AUDIBLE_REGIONS
+from .api import get_book_info, make_request, search_audible
+from .api import AUDIBLE_REGIONS, get_audible_album_url
 from .goodreads import get_original_date
 
 
@@ -106,6 +107,14 @@ class Audible(BeetsPlugin):
             mediafile.ASFStorageStyle("WM/SubTitle"),
         )
         self.add_media_field("subtitle", subtitle)
+
+        album_url = mediafile.MediaField(
+            mediafile.MP3StorageStyle("WOAF"),
+            mediafile.MP4StorageStyle("----:com.apple.iTunes:WWWAUDIOFILE"),
+            mediafile.StorageStyle("WOAF"),
+            mediafile.ASFStorageStyle("WM/AudioFileURL"),
+        )
+        self.add_media_field("album_url", album_url)
 
     def album_distance(self, items, album_info, mapping):
         dist = get_distance(data_source=self.data_source, info=album_info, config=self.config)
@@ -239,6 +248,7 @@ class Audible(BeetsPlugin):
             "comments": description,
             "data_source": "YAML",
             "subtitle": subtitle,
+            "album_url": None,
         }
 
         naturally_sorted_items = os_sorted(items, key=lambda i: util.bytestring_path(i.path))
@@ -380,6 +390,8 @@ class Audible(BeetsPlugin):
         cover_url = book.image_url
         genres = "/".join([g.name for g in book.genres])
 
+        album_url = get_audible_album_url(asin, book.region)
+
         common_attributes = {
             "artist_id": None,
             "asin": asin,
@@ -393,6 +405,7 @@ class Audible(BeetsPlugin):
             "data_source": self.data_source,
             "subtitle": subtitle,
             "catalognum": asin,
+            "album_url": album_url,
         }
 
         tracks = [

--- a/beetsplug/book.py
+++ b/beetsplug/book.py
@@ -75,6 +75,7 @@ class Book:
     summary_markdown: str
     tags: List[Tag]  # may be an empty list
     title: str
+    region: Optional[str]
 
     def __init__(
         self,
@@ -95,6 +96,7 @@ class Book:
         summary_markdown,
         tags,
         title,
+        region,
     ):
         self.asin = asin
         self.authors = authors
@@ -113,7 +115,7 @@ class Book:
         self.summary_markdown = summary_markdown
         self.tags = tags
         self.title = title
-        self.title = title
+        self.region = region
 
     @staticmethod
     def from_audnex_book(b: Dict):
@@ -163,6 +165,7 @@ class Book:
                 if g["type"] == "tag"
             ],
             title=b["title"],
+            region=b["region"],
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ packages = [{ include = "beetsplug" }]
 python = "^3.6"
 markdownify = "0.11.6"
 natsort = "8.2.0"
+tldextract = "5.1.2"
 
 [tool.poetry.dev-dependencies]
 beets = "1.6.0"

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,8 @@ This Beets plugin solves both problems.
      write_description_file: true # output desc.txt
      write_reader_file: true # output reader.txt
 
+     region: us # region to get metadata from, can be omitted, "us" by default, but this can be switched on a book-by-book basis during import
+
    copyartifacts:
      extensions: .yml # so that metadata.yml is copied, see below
 

--- a/readme.md
+++ b/readme.md
@@ -136,11 +136,11 @@ The following sources of information are used to search for book matches in orde
 
 If you're not getting a match for a book, try the following:
 
-1. Switch Audible service region to obtain metadata from:
+1. Check the tags on the files being imported. The album and artist tags should be set to the book title and author respectively.
+2. Press `E` when Beets prompts you about not being able to find a match. This prompts for the artist and album name. If the wrong book is being matched because there are other books with similar names on Audible, try using the audiobook's asin as the artist and title as the album.
+3. Switch Audible service region to obtain metadata from:
     * Set `region` in the beets config.
     * Press `R` to set region for a book when Beets prompts you about not being able to find a match or if it is incorrect.
-2. Check the tags on the files being imported. The album and artist tags should be set to the book title and author respectively.
-3. Press `E` when Beets prompts you about not being able to find a match. This prompts for the artist and album name. If the wrong book is being matched because there are other books with similar names on Audible, try using the audiobook's asin as the artist and title as the album.
 4. Specify the book's data by using `metadata.yml` if it isn't on Audible (see the next section).
 
 The plugin gets chapter data of each book and tries to match them to the imported files if and only if the number of imported files is the same as the number of chapters from Audible. This can fail and cause inaccurate track assignments if the lengths of the files don't match Audible's chapter data. If this happens, set the config option `match_chapters` to `false` temporarily and try again, and remember to uncomment that line once done.

--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,14 @@ This Beets plugin solves both problems.
 
      write_description_file: true # output desc.txt
      write_reader_file: true # output reader.txt
+     
+     region: us # the region from which to obtain metadata can be omitted, by default it is "us"
+                # pick one of the available values: au, ca, de, es, fr, in, it, jp, us, uk
 
-     region: us # region to get metadata from, can be omitted, "us" by default, but this can be switched on a book-by-book basis during import
-
+                # the region value can be set for each book individually during import/re-import
+                # also it is automatically derived from 'WOAF' (WWWAUDIOFILE) tag
+                # which may contain a URL such as 'https://www.audible.com/pd/ASINSTRING' or 'audible.com'
+   
    copyartifacts:
      extensions: .yml # so that metadata.yml is copied, see below
 
@@ -131,9 +136,12 @@ The following sources of information are used to search for book matches in orde
 
 If you're not getting a match for a book, try the following:
 
-1. Check the tags on the files being imported. The album and artist tags should be set to the book title and author respectively.
-2. Press `E` when Beets prompts you about not being able to find a match. This prompts for the artist and album name. If the wrong book is being matched because there are other books with similar names on Audible, try using the audiobook's asin as the artist and title as the album.
-3. Specify the book's data by using `metadata.yml` if it isn't on Audible (see the next section).
+1. Switch Audible service region to obtain metadata from:
+    * Set `region` in the beets config.
+    * Press `R` to set region for a book when Beets prompts you about not being able to find a match or if it is incorrect.
+2. Check the tags on the files being imported. The album and artist tags should be set to the book title and author respectively.
+3. Press `E` when Beets prompts you about not being able to find a match. This prompts for the artist and album name. If the wrong book is being matched because there are other books with similar names on Audible, try using the audiobook's asin as the artist and title as the album.
+4. Specify the book's data by using `metadata.yml` if it isn't on Audible (see the next section).
 
 The plugin gets chapter data of each book and tries to match them to the imported files if and only if the number of imported files is the same as the number of chapters from Audible. This can fail and cause inaccurate track assignments if the lengths of the files don't match Audible's chapter data. If this happens, set the config option `match_chapters` to `false` temporarily and try again, and remember to uncomment that line once done.
 
@@ -223,6 +231,7 @@ The plugin writes the following tags:
 | `TSOA` (ALBUMSORT)                       | If ALBUM only, then %Title%<br>If ALBUM and SUBTITLE, then %Title% - %Subtitle%<br>If Series, then %Series% %Series-part% - %Title% |
 | `TPUB` (PUBLISHER)                       | Publisher                                                                                                                           |
 | `ASIN` (ASIN)                            | Amazon Standard Identification Number                                                                                               |
+| `WOAF` (WWWAUDIOFILE)                    | Audible Album URL                                                                                                                   |
 | `stik` (media type), m4b only            | 2 (audiobook)                                                                                                                       |
 | `shwm` (show movement), m4b only         | 1 if part of a series                                                                                                               |
 | `MVNM` (MOVEMENTNAME)                    | Series                                                                                                                              |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beets-copyartifacts3
 markdownify
 natsort
+tldextract


### PR DESCRIPTION
I have attempted to implement support for various regions for the Audible and Audnex APIs. The manual region switch for `beet import` is currently available. This will partially solve my problem #66 and may help with #59.

What works:
- By default, the search will be performed on [audible.com](https://www.audible.com/) and the metadata will be obtained from [audnex.us](https://audnex.us/) for "us" region.
- There is a new configuration option called `region` to allow users to set the default region. This option is not required, it can be omitted, then default region will be "us". Available Audible regions: "au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk".
- The region can be switched for each book individually. Book level region value takes precedence over config level value.

Some features:
- During import/reimport, the `region` value is automatically derived from the `album_url` value which is stored in the `WOAF` (WWWAUDIOFILE) tag if it is available. This value may be a URL such as 'https://www.audible.com/pd/ASINSTRING' or 'audible.com'.
- During reimport the `region` field value takes precedence over value derived from `album_url`.
- The `region` field is not written to file tags, but  `album_url` field is because the `WOAF` (WWWAUDIOFILE) tag is used in the [Plex-Audiobook-Guide](https://github.com/seanap/Plex-Audiobook-Guide).
- `enter Id` retrieves metadata only from the region set at the configuration level, or uses the default one.

What is not implemented:
- Automatic search for candidates in different regions. _This is too complex for me._

Acknowledgments:
I am using the timid mode for the importer, as described in the [documentation](https://beets.readthedocs.io/en/stable/reference/config.html#timid).

I tested my code in these scenarios:
* configuration with `timid: yes`
* `beet import /one/book`
* `beet import /many/books`
* `beet import -L /audiobooks`

In these scenarios I tested not that extensively:
* configuration with `timid: no`
* `beet import /one/multi-file-book`