### PR TITLE
Add additonal field total_duration to AlbumInfo

### DIFF
--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -283,6 +283,8 @@ class Audible(BeetsPlugin):
         language = data.get("language", "English")
         publisher = data["publisher"]
 
+        total_duration_seconds = sum(track.length for track in tracks)
+
         return AlbumInfo(
             tracks=tracks,
             album=title,
@@ -298,6 +300,7 @@ class Audible(BeetsPlugin):
             original_day=day,
             language=language,
             label=publisher,
+            total_duration=ui.human_seconds_short(total_duration_seconds or 0.0),
             **common_attributes,
         )
 
@@ -456,6 +459,8 @@ class Audible(BeetsPlugin):
                 original_month = original_date.get("month")
                 original_day = original_date.get("day")
 
+        total_duration_seconds = sum(track.length for track in tracks)
+
         return AlbumInfo(
             tracks=tracks,
             album=title,
@@ -474,6 +479,7 @@ class Audible(BeetsPlugin):
             is_chapter_data_accurate=is_chapter_data_accurate,
             language=book.language,
             label=book.publisher,
+            total_duration=ui.human_seconds_short(total_duration_seconds or 0.0),
             **common_attributes,
         )
 


### PR DESCRIPTION
To differentiate between different versions (e.g. cut and uncut) of audibooks I want to have a total_duration field for each AlbumInfo.

(so I can display it in match.album_disambig_fields)

Feel free to rename it 😃 