### PR TITLE
Add option to keep original tracks (keep_org_tracks)

### DIFF
--- a/beetsplug/audible.py
+++ b/beetsplug/audible.py
@@ -28,6 +28,7 @@ class Audible(BeetsPlugin):
             {
                 "fetch_art": True,
                 "match_chapters": True,
+                "keep_org_tracks": False,
                 "source_weight": 0.0,
                 "write_description_file": True,
                 "write_reader_file": True,
@@ -192,6 +193,10 @@ class Audible(BeetsPlugin):
                 # Logging this for now because this situation
                 # is technically possible (based on the API) but unsure how often it happens
                 self._log.warn(f"Chapter data for {a.album} could be inaccurate.")
+
+            if self.config["keep_org_tracks"]:
+                # If the user has set the keep_org_tracks option, don't modify the tracks
+                return albums
 
             if is_likely_match and (not is_chapterized or not self.config["match_chapters"]):
                 self._log.debug(


### PR DESCRIPTION
Even with `match_chapters` == `False` the plugin sometimes manipulates the tracks: 
Actually exactly then when len(a.tracks) != len(items)

This then leads to a perfectly matching between items and tracks -> track amount and length is basically useless in the matching process (distance 0 instead of an actual high distance).

Therefore I added the new option `keep_org_tracks` to be able to disable the track manipulation by this plugin completely.
Note: I'm aware of that I then need to handle the matching/filling on my own...

If you want to make it optional it in another way it's also fine for me...